### PR TITLE
ci: validate that self parameters match the module's own type

### DIFF
--- a/src/Array.mo
+++ b/src/Array.mo
@@ -586,6 +586,7 @@ module {
   ///
   /// Space: O(number of elements in array)
   public func join<T>(self : Types.Iter<[T]>) : [T] {
+    // ignore-self-type-check
     flatten(fromIter(self))
   };
 

--- a/src/Int.mo
+++ b/src/Int.mo
@@ -116,6 +116,7 @@ module {
   /// assert "-1234".toInt() == ?-1234;
   /// ```
   public func toInt(self : Text) : ?Int {
+    // ignore-self-type-check
     fromText(self)
   };
 

--- a/src/List.mo
+++ b/src/List.mo
@@ -465,6 +465,7 @@ module {
   ///
   /// Space: O(number of elements in list)
   public func join<T>(self : Types.Iter<List<T>>) : List<T> {
+    // ignore-self-type-check
     let result = empty<T>();
     for (list in self) {
       reserve(result, size(list));
@@ -2024,6 +2025,7 @@ module {
   ///
   /// Runtime: `O(size)`
   public func toList<T>(self : Types.Iter<T>) : List<T> {
+    // ignore-self-type-check
     fromIter(self)
   };
 

--- a/src/Map.mo
+++ b/src/Map.mo
@@ -968,6 +968,7 @@ module {
   /// where `n` denotes the number of key-value entries returned by the iterator and
   /// assuming that the `compare` function implements an `O(1)` comparison.
   public func toMap<K, V>(self : Types.Iter<(K, V)>, compare : (implicit : (K, K) -> Order.Order)) : Map<K, V> {
+    // ignore-self-type-check
     fromIter(self, compare)
   };
 

--- a/src/Nat.mo
+++ b/src/Nat.mo
@@ -65,7 +65,7 @@ module {
   /// ```motoko include=import
   /// assert "1234".toNat() == ?1234;
   /// ```
-  public let toNat : (self : Text) -> ?Nat = fromText;
+  public let toNat : (self : Text) -> ?Nat = fromText; // ignore-self-type-check
 
   /// Converts an integer to a natural number. Traps if the integer is negative.
   /// @deprecated Use `Int.toNat` instead.

--- a/src/Option.mo
+++ b/src/Option.mo
@@ -104,7 +104,7 @@ module {
   /// import Option "mo:core/Option";
   /// assert Option.some(42) == ?42;
   /// ```
-  public func some<T>(self : T) : ?T = ?self;
+  public func some<T>(self : T) : ?T = ?self; // ignore-self-type-check
 
   /// Returns true if the argument is not `null`, otherwise returns false.
   public func isSome(self : ?Any) : Bool {

--- a/src/Queue.mo
+++ b/src/Queue.mo
@@ -457,6 +457,7 @@ module {
   /// Space: O(n)
   /// `n` denotes the number of elements stored in the queue.
   public func toQueue<T>(self : Iter.Iter<T>) : Queue<T> {
+    // ignore-self-type-check
     fromIter(self)
   };
 

--- a/src/Set.mo
+++ b/src/Set.mo
@@ -749,6 +749,7 @@ module {
   /// where `n` denotes the number of elements returned by the iterator and
   /// assuming that the `compare` function implements an `O(1)` comparison.
   public func toSet<T>(self : Types.Iter<T>, compare : (implicit : (T, T) -> Order.Order)) : Set<T> {
+    // ignore-self-type-check
     fromIter(self, compare)
   };
 

--- a/src/Stack.mo
+++ b/src/Stack.mo
@@ -809,6 +809,7 @@ module {
   /// Space: O(n)
   /// where `n` denotes the number of iterated elements.
   public func toStack<T>(self : Types.Iter<T>) : Stack<T> {
+    // ignore-self-type-check
     fromIter(self)
   };
 

--- a/src/Text.mo
+++ b/src/Text.mo
@@ -330,6 +330,7 @@ module {
   /// assert joined == "a, b, c";
   /// ```
   public func join(self : Iter.Iter<Text>, sep : Text) : Text {
+    // ignore-self-type-check
     var r = "";
     if (sep.size() == 0) {
       for (t in self) {
@@ -934,7 +935,7 @@ module {
   /// let text = Text.decodeUtf8("\48\65\6C\6C\6F");
   /// assert text == ?"Hello";
   /// ```
-  public let decodeUtf8 : (self : Blob) -> ?Text = Prim.decodeUtf8;
+  public let decodeUtf8 : (self : Blob) -> ?Text = Prim.decodeUtf8; // ignore-self-type-check
 
   /// Returns the text argument in lowercase.
   /// WARNING: Unicode compliant only when compiled, not interpreted.

--- a/src/VarArray.mo
+++ b/src/VarArray.mo
@@ -782,6 +782,7 @@ module {
   ///
   /// Space: O(number of elements in array)
   public func join<T>(self : Types.Iter<[var T]>) : [var T] {
+    // ignore-self-type-check
     flatten<T>(fromIter(self))
   };
 

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -1069,6 +1069,7 @@ module {
   ///
   /// Space: O(size)
   public func toList<T>(self : Iter.Iter<T>) : List<T> {
+    // ignore-self-type-check
     fromIter(self)
   };
 

--- a/src/pure/Map.mo
+++ b/src/pure/Map.mo
@@ -622,7 +622,7 @@ module {
   /// assuming that the `compare` function implements an `O(1)` comparison.
   ///
   /// Note: Creates `O(n * log(n))` temporary objects that will be collected as garbage.
-  public func toMap<K, V>(self : Iter.Iter<(K, V)>, compare : (implicit : (K, K) -> Order.Order)) : Map<K, V> = Internal.fromIter(self, compare);
+  public func toMap<K, V>(self : Iter.Iter<(K, V)>, compare : (implicit : (K, K) -> Order.Order)) : Map<K, V> = Internal.fromIter(self, compare); // ignore-self-type-check
 
   /// Given a `map` and function `f`, creates a new map by applying `f` to each entry in the map `m`. Each entry
   /// `(k, v)` in the old map is transformed into a new entry `(k, v2)`, where

--- a/src/pure/Queue.mo
+++ b/src/pure/Queue.mo
@@ -327,6 +327,7 @@ module {
   ///
   /// Space: O(size)
   public func toQueue<T>(self : Iter.Iter<T>) : Queue<T> {
+    // ignore-self-type-check
     fromIter(self)
   };
 

--- a/src/pure/RealTimeQueue.mo
+++ b/src/pure/RealTimeQueue.mo
@@ -565,6 +565,7 @@ module {
   ///
   /// Space: `O(size)`
   public func toQueue<T>(self : Iter<T>) : Queue<T> {
+    // ignore-self-type-check
     fromIter(self)
   };
 

--- a/src/pure/Set.mo
+++ b/src/pure/Set.mo
@@ -110,6 +110,7 @@ module {
   ///
   /// Note: Creates `O(n * log(n))` temporary objects that will be collected as garbage.
   public func toSet<T>(self : Iter.Iter<T>, compare : (implicit : (T, T) -> Order.Order)) : Set<T> {
+    // ignore-self-type-check
     fromIter(self, compare)
   };
 
@@ -1050,6 +1051,7 @@ module {
   /// where `n` denotes the number of elements stored in the iterated sets,
   /// and assuming that the `compare` function implements an `O(1)` comparison.
   public func join<T>(self : Iter.Iter<Set<T>>, compare : (implicit : (T, T) -> Order.Order)) : Set<T> {
+    // ignore-self-type-check
     var result = empty<T>();
     for (set in self) {
       result := union(result, set, compare)

--- a/test/ts/validate/api/checkSelfTypes.ts
+++ b/test/ts/validate/api/checkSelfTypes.ts
@@ -1,0 +1,105 @@
+// Every public function whose first parameter is named `self` must take the module's
+// own type (e.g. all `self` parameters in Nat.mo are of type `Nat`), so that contextual
+// dot notation resolves where readers expect. Intentional exceptions such as conversion
+// functions (`List.toList(self : Iter<T>)`, used as `iter.toList()`) are marked with an
+// `// ignore-self-type-check` comment on the declaration.
+
+import { readFileSync } from "fs";
+import { basename, join, relative } from "path";
+import glob from "fast-glob";
+
+const rootDir = join(__dirname, "../../../..");
+const srcDir = join(rootDir, "src");
+
+const IGNORE_MARKER = "ignore-self-type-check";
+
+// Modules whose subject type is not simply named after the file
+const expectedHeadOverrides: Record<string, string> = {
+  Array: "[]",
+  VarArray: "[var]",
+  Option: "?",
+  RealTimeQueue: "Queue",
+};
+
+// Reduces a type to the shape used for comparison: an array, a mutable array, an option,
+// or the last segment of the leading type path (`Types.List<T>` -> "List")
+function typeHead(type: string): string {
+  if (type.startsWith("[var")) return "[var]";
+  if (type.startsWith("[")) return "[]";
+  if (type.startsWith("?")) return "?";
+  const match = type.match(/^[A-Za-z_][A-Za-z0-9_.]*/);
+  if (!match) return type;
+  const path = match[0].split(".");
+  return path[path.length - 1];
+}
+
+// Reads the `self` parameter's type starting at `start`, up to the end of the first
+// parameter (a `,` or `)` outside any nested brackets)
+function parseSelfType(source: string, start: number): [string, number] {
+  let depth = 0;
+  let i = start;
+  while (i < source.length) {
+    const c = source[i];
+    if (c === "<" || c === "(" || c === "[") depth++;
+    else if (c === "]" || (c === ">" && source[i - 1] !== "-")) depth--;
+    else if (c === ")") {
+      if (depth === 0) break;
+      depth--;
+    } else if (c === "," && depth === 0) break;
+    i++;
+  }
+  return [source.slice(start, i).replace(/\s+/g, " ").trim(), i];
+}
+
+const errors: string[] = [];
+
+const moFiles = glob.sync(join(srcDir, "**/*.mo")).sort();
+if (moFiles.length === 0) {
+  throw new Error("Expected at least one Motoko file in `src` directory");
+}
+moFiles.forEach((srcPath) => {
+  const moduleName = basename(srcPath, ".mo");
+  const expectedHead = expectedHeadOverrides[moduleName] ?? moduleName;
+  const source = readFileSync(srcPath, "utf8");
+
+  // Same declaration shape as the api.lock.json parser in `index.ts`
+  const declarationRegex =
+    /\n {2}(public\s+(?:func|let|class)\s+\w+[^{=]*?)\(\s*self\s*:\s*/g;
+  let match;
+  while ((match = declarationRegex.exec(source)) !== null) {
+    const [matched, prefix] = match;
+    // A `)` before the matched paren means `self` is not in the declaration's
+    // first parameter list
+    if (prefix.includes(")")) continue;
+
+    const [selfType, typeEnd] = parseSelfType(
+      source,
+      match.index + matched.length
+    );
+    // The marker window covers the declaration plus one more line, since prettier
+    // moves a trailing comment on a `func` declaration into the body's first line
+    const declarationEnd = source.indexOf("\n", typeEnd);
+    const markerWindow = source.slice(
+      match.index,
+      source.indexOf("\n", declarationEnd + 1)
+    );
+    if (markerWindow.includes(IGNORE_MARKER)) continue;
+
+    if (typeHead(selfType) !== expectedHead) {
+      const line = source.slice(0, match.index).split("\n").length + 1;
+      const name = prefix.replace(/\s+/g, " ").trim();
+      errors.push(
+        `${relative(rootDir, srcPath)}:${line}: \`${name}\` takes ` +
+          `\`self : ${selfType}\`, but every \`self\` in ${moduleName}.mo should be of ` +
+          `type \`${expectedHead}\` so that contextual dot notation resolves as expected.\n` +
+          `If the mismatch is intentional (e.g. a conversion function), add an ` +
+          `\`// ${IGNORE_MARKER}\` comment to the declaration.`
+      );
+    }
+  }
+});
+
+if (errors.length) {
+  errors.forEach((error) => console.error(error + "\n"));
+  process.exit(1);
+}

--- a/test/ts/validate/api/index.ts
+++ b/test/ts/validate/api/index.ts
@@ -1,2 +1,3 @@
 import "./checkReferences";
+import "./checkSelfTypes";
 import "./spec";


### PR DESCRIPTION
`Nat.mo` shipped `public let toNat : (self : Text) -> ?Nat` for a while without anyone noticing the foreign `self` type — nothing catches a `self` parameter that doesn't match its module, and the mistake still type-checks (see also [#492](https://github.com/caffeinelabs/motoko-core/pull/492), [#456](https://github.com/caffeinelabs/motoko-core/pull/456), which fixed the same class of bug by hand).

`validate:api` now fails if a public function's first parameter is named `self` but its type doesn't match the module's own type (`Nat` in `Nat.mo`, `List<T>` in `List.mo`, `[var T]` in `VarArray.mo`, `?T` in `Option.mo`, ...):

```
src/Nat.mo:68: `public let toNat :` takes `self : Text`, but every `self` in Nat.mo
should be of type `Nat` so that contextual dot notation resolves as expected.
If the mismatch is intentional (e.g. a conversion function), add an
`// ignore-self-type-check` comment to the declaration.
```

## What is unchanged

The 19 existing deviations are all deliberate target-module conversions (`iter.toList()`, `"1234".toNat()`, `blob.decodeUtf8()`, `Option.some`, the `join` family) and keep working — each now carries an `// ignore-self-type-check` marker, following the existing `ignore-reference-check` convention. Whether to migrate them to a single source-type convention is tracked separately in [#524](https://github.com/caffeinelabs/motoko-core/issues/524).

No workflow changes: the check runs inside the existing `validate-api` job. `api.lock.json` is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)