### PR TITLE
docs: expand AGENTS.md CI and toolchain gotchas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 - Requires Node.js 24 (CI uses `node-version: 24`).
 - Run `npm ci`. The `postinstall` script runs `mops install`, which fetches Motoko dependencies and the pinned toolchain declared in `mops.toml`.
-- The Motoko toolchain versions (`moc`, `wasmtime`, `pocket-ic`) are pinned under `[toolchain]` in `mops.toml`; do not assume system-installed versions.
+- The Motoko toolchain versions (`moc`, `wasmtime`, `pocket-ic`) are pinned under `[toolchain]` in `mops.toml`; do not assume system-installed versions. `[requirements] moc` is a minimum floor; `[toolchain] moc` is what CI pins and runs on.
 
 ## Build, test, lint, format
 
@@ -15,11 +15,13 @@ Use the `package.json` scripts:
 - `npm test` — full test suite (`test:ts` then `test:mops`).
 - `npm run test:mops` — Motoko unit tests via `mops test`.
 - `npm run test:ts` — TypeScript integration tests (`test/ts`).
-- `npm run bench` — benchmarks (`mops bench`); run in CI as `check:bench`.
+- `npm run bench` — benchmarks (`mops bench`); run in CI by the `bench` job.
 - `npm run check:orphans` — type-checks Motoko modules not otherwise imported.
 - `npm run format:check` — Prettier check on `*.mo` files. `npm run format` rewrites them.
 - `npm run validate` — runs `validate:changelog`, `validate:version`, `validate:api`.
 - `npm run validate:docs [Module ...]` — runs doc-comment code examples for the named `src/*.mo` modules (or all when no argument).
+- `npm run docs` — generates `docs/` via mo-doc (CI builds it in `gh-pages.yml`).
+- `npm run check:mo` — runs `test:mops`, `bench`, and `check:orphans` together.
 
 Formatting is enforced by the `prettier-plugin-motoko` plugin with the `*.mo` overrides in `.prettierrc` (2-space indent, no semicolons, no trailing commas).
 
@@ -33,9 +35,13 @@ Formatting is enforced by the `prettier-plugin-motoko` plugin with the `*.mo` ov
 ## Conventions and CI gotchas
 
 - The public API is locked in `validation/api/api.lock.json`. CI fails if `npm run validate:api` produces a diff; regenerate with `npm run validate` and commit the result when the public API changes intentionally.
-- CI requires `Changelog.md` to be updated when any `src/*.mo` file changes (advisory) — keep it current.
+- CI requires `Changelog.md` to be updated when any `src/*.mo` file changes — advisory in `tests.yml` (warns only), mandatory on a release PR where `release-tag.yml` blocks the tag if it does not match the bumped version.
 - `npm run validate:version` cross-checks the version; the `version` in `mops.toml` is the source of truth (`package.json` version is `0.0.0`).
+- See `Releasing.md` for the release steps (version bump, changelog, tag, publish).
 - Every public function should carry a doc comment with a runnable example, since `validate:docs` executes them (see `Styleguide.md`).
 - Follow `Styleguide.md` for interface and code-style conventions.
 - Generated/local directories are git-ignored and must not be committed: `.mops/`, `docs/`, `test/generated/`, `_build/`, `_out/`.
 - `.npmrc` sets `min-release-age=7`; newly published dependency versions younger than 7 days are not installed.
+- `mops.toml` sets `[moc] args = ["-E=M0154,M0223"]`, demoting those two unused-identifier errors to warnings.
+- `tests.yml` gates all jobs on one required aggregate job `ci:required` (most jobs are conditional; a skipped job would otherwise satisfy its required check). `test` and `bench` run only on `.mo`/mops/tooling changes.
+- The `test` job also runs one Motoko test under legacy persistence: `npx ic-mops test List.allocation -- --legacy-persistence`.


### PR DESCRIPTION
## Summary
Updates `AGENTS.md` so it stays an accurate agent-facing reference for this repo.

- Clarifies the `moc` toolchain nuance: `[requirements]` is a minimum floor, `[toolchain]` is what CI pins and runs on.
- Adds the `docs` and `check:mo` npm scripts to the reference.
- Documents the `[moc] args = ["-E=M0154,M0223"]` depromotion.
- Documents the single required `ci:required` aggregate gate and that `test`/`bench` run only on Motoko/mops/tooling changes.
- Documents that the changelog is advisory in `tests.yml` but mandatory on release, and points to `Releasing.md` for release steps.
- Fixes a stale claim: the `bench` script is run in CI by the `bench` job (`npm run bench`), not `check:bench`.

## Test plan
Docs-only change; no Motoko source touched, so `validate:api`/`validate:docs`/changelog are unaffected. Verified every fact against `mops.toml`, `package.json`, `.github/workflows/*.yml`, and `Releasing.md` via an independent fact-check pass.

Made with [Cursor](https://cursor.com)