### PR TITLE
docs: record interface conventions in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,6 @@ Formatting is enforced by the `prettier-plugin-motoko` plugin with the `*.mo` ov
 
 - Prefer `toX` with `self` as first parameter over `fromX`; `fromX` may exist for legacy reasons but must never take the `self` parameter (exception: legacy preexisting functions).
 - Every context-dot function whose first parameter is `self` must type it as the module's own type, e.g. `toX(self : Nat) : X` belongs in `Nat.mo`. CI-enforced; escape hatch is a `// ignore-self-type-check` comment.
-- Higher-order functions put the function parameter last (after `self`), e.g. `map(self, f)`, `find(self, predicate)`.
 - Every data-structure/primitive module provides `equal`, `compare`, `toText`; `compare` returns `Types.Order`.
 - Public modules open with a one-line purpose, then a `/// ```motoko name=import``` snippet preceded by "Import from the core package to use this module." (see `src/Nat.mo`).
 - Data-structure functions document asymptotic cost as `Runtime: O(...)` and `Space: O(...)` lines at the end of the doc comment.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,15 @@ Formatting is enforced by the `prettier-plugin-motoko` plugin with the `*.mo` ov
 - `bench/` — benchmarks (`*.bench.mo`).
 - `validation/` — checked-in fixtures, including the public API lockfile `validation/api/api.lock.json`.
 
+## Interface conventions
+
+- Prefer `toX` with `self` as first parameter over `fromX`; `fromX` may exist for legacy reasons but must never take the `self` parameter (exception: legacy preexisting functions).
+- Every context-dot function whose first parameter is `self` must type it as the module's own type, e.g. `toX(self : Nat) : X` belongs in `Nat.mo`. CI-enforced; escape hatch is a `// ignore-self-type-check` comment.
+- Higher-order functions put the function parameter last (after `self`), e.g. `map(self, f)`, `find(self, predicate)`.
+- Every data-structure/primitive module provides `equal`, `compare`, `toText`; `compare` returns `Types.Order`.
+- Public modules open with a one-line purpose, then a `/// ```motoko name=import``` snippet preceded by "Import from the core package to use this module." (see `src/Nat.mo`).
+- Data-structure functions document asymptotic cost as `Runtime: O(...)` and `Space: O(...)` lines at the end of the doc comment.
+
 ## Conventions and CI gotchas
 
 - The public API is locked in `validation/api/api.lock.json`. CI fails if `npm run validate:api` produces a diff; regenerate with `npm run validate` and commit the result when the public API changes intentionally.


### PR DESCRIPTION
## Summary
Adds an `## Interface conventions` section to `AGENTS.md` so agent and human contributors have one place stating how this repo wants interfaces shaped.

Captured conventions, all verified against current source:
- Prefer `toX` (self first) over `fromX`; `fromX` must never take `self` (legacy exceptions aside).
- Context-dot functions whose first parameter is `self` must type it as the module's own type, e.g. `toX(self : Nat)` belongs in `Nat.mo`. Now CI-enforced, with a `// ignore-self-type-check` escape hatch.
- Every data-structure/primitive module provides uniform `equal`, `compare`, `toText` (`compare` returns `Order`).
- Standard module doc-comment header (`motoko name=import` snippet).
- Data-structure doc comments annotate `Runtime:`/`Space:` complexity.

The two toX/fromX + self-type rules are straight from the team; the rest were surfaced by auditing `Styleguide.md`, settled modules, and git history, then independently fact-checked against `src/`.

Note: a higher-order-param-last rule was considered but dropped after review showed `Map.mo` puts the ordering callback right after `self` in accessor functions (e.g. `get`, `insert`, `remove`), so the repo does not consistently follow the Styleguide's "function parameter last" guidance. AGENTS.md intentionally omits that contested convention.

## Test plan
Docs-only change, no Motoko source touched. Every rule was verified against `src/` (signatures, `Order` return types, doc-comment headers, `Runtime:`/`Space:` labels) before landing.