### PR TITLE
Replace deprecated .vals() with .values() across the codebase

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,5 @@
 ## Next
-* Replace all uses of the deprecated `.vals()` array/blob iterator method with `.values()` across `src`, `test`, and `bench` (#PR).
+* Replace all uses of the deprecated `.vals()` array/blob iterator method with `.values()` across `src`, `test`, and `bench` (#530).
 
 ## 2.6.1
 * Remove unnecessary allocations in `List` functions. Raise `List` size limit to `2^61` (#515).

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 ## Next
+* Replace all uses of the deprecated `.vals()` array/blob iterator method with `.values()` across `src`, `test`, and `bench` (#PR).
 
 ## 2.6.1
 * Remove unnecessary allocations in `List` functions. Raise `List` size limit to `2^61` (#515).

--- a/bench/FromIters.bench.mo
+++ b/bench/FromIters.bench.mo
@@ -42,9 +42,9 @@ module {
           case _ Runtime.unreachable()
         };
         switch row {
-          case "List.fromIter" ignore List.fromIter(array.vals());
-          case "List.fromIter . Iter.reverse" ignore List.fromIter(Iter.reverse(array.vals()));
-          case "Iter.toArray" ignore array.vals().toArray();
+          case "List.fromIter" ignore List.fromIter(array.values());
+          case "List.fromIter . Iter.reverse" ignore List.fromIter(Iter.reverse(array.values()));
+          case "Iter.toArray" ignore array.values().toArray();
           case _ Runtime.unreachable()
         }
       }

--- a/bench/Queues.bench.mo
+++ b/bench/Queues.bench.mo
@@ -45,21 +45,21 @@ module {
 
     bench.runner(
       func(row, col) = switch (col, row) {
-        case ("pure/RealTimeQueue", "Initialize with 2 elements") newQ := NewQueue.fromIter<Nat>(init.vals());
-        case ("pure/Queue", "Initialize with 2 elements") oldQ := OldQueue.fromIter<Nat>(init.vals());
-        case ("mutable Queue", "Initialize with 2 elements") mutQ := MutQueue.fromIter<Nat>(init.vals());
+        case ("pure/RealTimeQueue", "Initialize with 2 elements") newQ := NewQueue.fromIter<Nat>(init.values());
+        case ("pure/Queue", "Initialize with 2 elements") oldQ := OldQueue.fromIter<Nat>(init.values());
+        case ("mutable Queue", "Initialize with 2 elements") mutQ := MutQueue.fromIter<Nat>(init.values());
         case ("pure/RealTimeQueue", "Push 500 elements") {
-          for (i in toPush.vals()) {
+          for (i in toPush.values()) {
             newQ := NewQueue.pushBack<Nat>(newQ, i)
           }
         };
         case ("pure/Queue", "Push 500 elements") {
-          for (i in toPush.vals()) {
+          for (i in toPush.values()) {
             oldQ := OldQueue.pushBack<Nat>(oldQ, i)
           }
         };
         case ("mutable Queue", "Push 500 elements") {
-          for (i in toPush.vals()) {
+          for (i in toPush.values()) {
             MutQueue.pushBack<Nat>(mutQ, i)
           }
         };

--- a/src/Array.mo
+++ b/src/Array.mo
@@ -158,7 +158,7 @@ module {
   ///
   /// *Runtime and space assumes that `predicate` runs in O(1) time and space.
   public func find<T>(self : [T], predicate : T -> Bool) : ?T {
-    for (element in self.vals()) {
+    for (element in self.values()) {
       if (predicate(element)) {
         return ?element
       }
@@ -269,7 +269,7 @@ module {
   ///
   /// *Runtime and space assumes that `f` runs in O(1) time and space.
   public func forEach<T>(self : [T], f : T -> ()) {
-    for (item in self.vals()) {
+    for (item in self.values()) {
       f(item)
     }
   };
@@ -606,7 +606,7 @@ module {
   /// Space: O(number of elements in array)
   public func flatten<T>(self : [[T]]) : [T] {
     var flatSize = 0;
-    for (subArray in self.vals()) {
+    for (subArray in self.values()) {
       flatSize += subArray.size()
     };
 
@@ -899,7 +899,7 @@ module {
   ///
   /// Space: O(1)
   public func contains<T>(self : [T], equal : (implicit : (T, T) -> Bool), element : T) : Bool {
-    for (item in self.vals()) {
+    for (item in self.values()) {
       if (equal(item, element)) {
         return true
       }

--- a/src/Iter.mo
+++ b/src/Iter.mo
@@ -737,13 +737,13 @@ module {
 
   /// Creates an iterator that produces the elements of an Array in ascending index order.
   /// @deprecated Use `Array.values` instead.
-  public func fromArray<T>(array : [T]) : Iter<T> = array.vals();
+  public func fromArray<T>(array : [T]) : Iter<T> = array.values();
 
   /// Like `fromArray` but for Arrays with mutable elements. Captures
   /// the elements of the Array at the time the iterator is created, so
   /// further modifications won't be reflected in the iterator.
   /// @deprecated Use `VarArray.values` instead.
-  public func fromVarArray<T>(array : [var T]) : Iter<T> = array.vals();
+  public func fromVarArray<T>(array : [var T]) : Iter<T> = array.values();
 
   /// Consumes an iterator and collects its produced elements in an Array.
   /// ```motoko include=import

--- a/src/List.mo
+++ b/src/List.mo
@@ -457,7 +457,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let lists = [List.fromArray<Nat>([0, 1, 2]), List.fromArray<Nat>([2, 3]), List.fromArray<Nat>([]), List.fromArray<Nat>([4])];
-  /// let joinedList = List.join(lists.vals());
+  /// let joinedList = List.join(lists.values());
   /// assert List.equal<Nat>(joinedList, List.fromArray<Nat>([0, 1, 2, 2, 3, 4]), Nat.equal);
   /// ```
   ///
@@ -835,7 +835,7 @@ module {
   /// import Int "mo:core/Int"
   ///
   /// let list = List.fromArray<Nat>([1, 2, 3, 4]);
-  /// let newList = List.flatMap(list, func x = [x, -x].vals());
+  /// let newList = List.flatMap(list, func x = [x, -x].values());
   /// assert List.equal(newList, List.fromArray<Int>([1, -1, 2, -2, 3, -3, 4, -4]), Int.equal);
   /// ```
   /// Runtime: O(size)
@@ -1995,7 +1995,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// let array = [1, 1, 1];
-  /// let iter = array.vals();
+  /// let iter = array.values();
   ///
   /// let list = List.fromIter<Nat>(iter);
   /// assert Iter.toArray(List.values(list)) == [1, 1, 1];
@@ -2017,7 +2017,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// let array = [1, 1, 1];
-  /// let iter = array.vals();
+  /// let iter = array.values();
   ///
   /// let list = iter.toList<Nat>();
   /// assert Iter.toArray(List.values(list)) == [1, 1, 1];
@@ -2074,7 +2074,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// let array = [1, 1, 1];
-  /// let iter = array.vals();
+  /// let iter = array.values();
   /// let list = List.repeat<Nat>(2, 1);
   ///
   /// List.addAll<Nat>(list, iter);

--- a/src/Principal.mo
+++ b/src/Principal.mo
@@ -1216,8 +1216,8 @@ module {
       }
     };
 
-    public func writeArray(arr : [Nat8]) : () = writeIter(arr.vals());
-    public func writeBlob(blob : Blob) : () = writeIter(blob.vals());
+    public func writeArray(arr : [Nat8]) : () = writeIter(arr.values());
+    public func writeBlob(blob : Blob) : () = writeIter(blob.values());
 
     public func sum() : Blob {
       // calculate padding

--- a/src/Queue.mo
+++ b/src/Queue.mo
@@ -480,7 +480,7 @@ module {
   /// `n` denotes the number of elements stored in the array.
   public func fromArray<T>(array : [T]) : Queue<T> {
     let queue = empty<T>();
-    for (element in array.vals()) {
+    for (element in array.values()) {
       pushBack(queue, element)
     };
     queue

--- a/src/Set.mo
+++ b/src/Set.mo
@@ -8,7 +8,7 @@
 /// import Nat "mo:core/Nat";
 ///
 /// persistent actor {
-///   let set = Set.fromIter([3, 1, 2, 3].vals(), Nat.compare);
+///   let set = Set.fromIter([3, 1, 2, 3].values(), Nat.compare);
 ///   assert Set.size(set) == 3;
 ///   assert not Set.contains(set, Nat.compare, 4);
 ///   let diff = Set.difference(set, set, Nat.compare);
@@ -988,7 +988,7 @@ module {
     deleteAll(
       self,
       compare,
-      Iter.filter<T>(array.vals(), func(element : T) : Bool = not predicate(element))
+      Iter.filter<T>(array.values(), func(element : T) : Bool = not predicate(element))
     )
   };
 

--- a/src/Text.mo
+++ b/src/Text.mo
@@ -61,7 +61,7 @@ module {
   ///
   /// Runtime: O(a.size())
   /// Space: O(a.size())
-  public func fromArray(a : [Char]) : Text = fromIter(a.vals());
+  public func fromArray(a : [Char]) : Text = fromIter(a.values());
 
   /// Converts the given `[var Char]` to a `Text` value.
   ///
@@ -72,7 +72,7 @@ module {
   ///
   /// Runtime: O(a.size())
   /// Space: O(a.size())
-  public func fromVarArray(a : [var Char]) : Text = fromIter(a.vals());
+  public func fromVarArray(a : [var Char]) : Text = fromIter(a.values());
 
   /// Iterates over each `Char` value in the given `Text`.
   ///

--- a/src/VarArray.mo
+++ b/src/VarArray.mo
@@ -130,7 +130,7 @@ module {
   ///
   /// *Runtime and space assumes that `predicate` runs in O(1) time and space.
   public func find<T>(self : [var T], predicate : T -> Bool) : ?T {
-    for (element in self.vals()) {
+    for (element in self.values()) {
       if (predicate element) {
         return ?element
       }
@@ -417,7 +417,7 @@ module {
   ///
   /// *Runtime and space assumes that `f` runs in O(1) time and space.
   public func forEach<T>(self : [var T], f : T -> ()) {
-    for (item in self.vals()) {
+    for (item in self.values()) {
       f(item)
     }
   };
@@ -671,7 +671,7 @@ module {
   /// import Int "mo:core/Int"
   ///
   /// let array = [var 1, 2, 3, 4];
-  /// let newArray = VarArray.flatMap(array, func x = [x, -x].vals());
+  /// let newArray = VarArray.flatMap(array, func x = [x, -x].values());
   /// assert VarArray.equal(newArray, [var 1, -1, 2, -2, 3, -3, 4, -4], Int.equal);
   /// ```
   /// Runtime: O(size)
@@ -731,7 +731,7 @@ module {
   /// *Runtime and space assumes that `combine` runs in O(1) time and space.
   public func foldLeft<T, A>(self : [var T], base : A, combine : (A, T) -> A) : A {
     var acc = base;
-    for (element in self.vals()) {
+    for (element in self.values()) {
       acc := combine(acc, element)
     };
     acc
@@ -774,7 +774,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let arrays : [[var Nat]] = [[var 0, 1, 2], [var 2, 3], [var], [var 4]];
-  /// let joinedArray = VarArray.join(arrays.vals());
+  /// let joinedArray = VarArray.join(arrays.values());
   /// assert VarArray.equal(joinedArray, [var 0, 1, 2, 2, 3, 4], Nat.equal);
   /// ```
   ///
@@ -804,7 +804,7 @@ module {
   /// Space: O(number of elements in array)
   public func flatten<T>(self : [var [var T]]) : [var T] {
     var flatSize = 0;
-    for (subArray in self.vals()) {
+    for (subArray in self.values()) {
       flatSize += subArray.size()
     };
 
@@ -933,7 +933,7 @@ module {
   /// Runtime: O(1)
   ///
   /// Space: O(1)
-  public func values<T>(self : [var T]) : Types.Iter<T> = self.vals();
+  public func values<T>(self : [var T]) : Types.Iter<T> = self.values();
 
   /// Returns an iterator that provides pairs of (index, element) in order, or `null`
   /// when out of elements to iterate over.
@@ -1106,7 +1106,7 @@ module {
   ///
   /// Space: O(1)
   public func contains<T>(self : [var T], equal : (implicit : (T, T) -> Bool), element : T) : Bool {
-    for (item in self.vals()) {
+    for (item in self.values()) {
       if (equal(item, element)) {
         return true
       }

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -1035,7 +1035,7 @@ module {
   /// import List "mo:core/pure/List";
   ///
   /// persistent actor {
-  ///   let list = List.fromIter([0, 1, 2, 3, 4].vals());
+  ///   let list = List.fromIter([0, 1, 2, 3, 4].values());
   ///   assert list == ?(0, ?(1, ?(2, ?(3, ?(4, null)))));
   /// }
   /// ```
@@ -1057,7 +1057,7 @@ module {
   /// import List "mo:core/pure/List";
   ///
   /// persistent actor {
-  ///   transient let iter = [0, 1, 2, 3, 4].vals();
+  ///   transient let iter = [0, 1, 2, 3, 4].values();
   ///
   ///   let list = iter.toList();
   ///

--- a/test/Array.test.mo
+++ b/test/Array.test.mo
@@ -303,19 +303,19 @@ let suite = Suite.suite(
     ),
     Suite.test(
       "flatMap",
-      Array.flatMap<Int, Int>([0, 1, 2], func x = [x, -x].vals()),
+      Array.flatMap<Int, Int>([0, 1, 2], func x = [x, -x].values()),
       M.equals(T.array<Int>(T.intTestable, [0, 0, 1, -1, 2, -2]))
     ),
     Suite.test(
       "flatMap empty",
-      Array.flatMap<Int, Int>([], func x = [x, -x].vals()),
+      Array.flatMap<Int, Int>([], func x = [x, -x].values()),
       M.equals(T.array<Int>(T.intTestable, []))
     ),
     Suite.test(
       "flatMap mix",
       Array.flatMap<Nat, Nat>(
         [1, 2, 1, 2, 3],
-        func n = Array.tabulate<Nat>(n, func i = i).vals()
+        func n = Array.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(T.array<Nat>(T.natTestable, [0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -323,7 +323,7 @@ let suite = Suite.suite(
       "flatMap mix empty right",
       Array.flatMap<Nat, Nat>(
         [0, 1, 2, 0, 1, 2, 3, 0],
-        func n = Array.tabulate<Nat>(n, func i = i).vals()
+        func n = Array.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(T.array<Nat>(T.natTestable, [0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -331,7 +331,7 @@ let suite = Suite.suite(
       "flatMap mix empties right",
       Array.flatMap<Nat, Nat>(
         [0, 1, 2, 0, 1, 2, 3, 0, 0, 0],
-        func n = Array.tabulate<Nat>(n, func i = i).vals()
+        func n = Array.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(T.array<Nat>(T.natTestable, [0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -339,7 +339,7 @@ let suite = Suite.suite(
       "flatMap mix empty left",
       Array.flatMap<Nat, Nat>(
         [0, 1, 2, 0, 1, 2, 3],
-        func n = Array.tabulate<Nat>(n, func i = i).vals()
+        func n = Array.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(T.array<Nat>(T.natTestable, [0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -347,7 +347,7 @@ let suite = Suite.suite(
       "flatMap mix empties left",
       Array.flatMap<Nat, Nat>(
         [0, 0, 0, 1, 2, 0, 1, 2, 3],
-        func n = Array.tabulate<Nat>(n, func i = i).vals()
+        func n = Array.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(T.array<Nat>(T.natTestable, [0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -355,7 +355,7 @@ let suite = Suite.suite(
       "flatMap mix empties middle",
       Array.flatMap<Nat, Nat>(
         [0, 1, 2, 0, 0, 0, 1, 2, 3],
-        func n = Array.tabulate<Nat>(n, func i = i).vals()
+        func n = Array.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(T.array<Nat>(T.natTestable, [0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -363,7 +363,7 @@ let suite = Suite.suite(
       "flatMap mix empties",
       Array.flatMap<Nat, Nat>(
         [0, 0, 0],
-        func n = Array.tabulate<Nat>(n, func i = i).vals()
+        func n = Array.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(T.array<Nat>(T.natTestable, []))
     ),
@@ -371,7 +371,7 @@ let suite = Suite.suite(
       "flatMap mix empty",
       Array.flatMap<Nat, Nat>(
         [],
-        func n = Array.tabulate<Nat>(n, func i = i).vals()
+        func n = Array.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(T.array<Nat>(T.natTestable, []))
     ),

--- a/test/Base64.test.mo
+++ b/test/Base64.test.mo
@@ -164,7 +164,7 @@ suite(
           "Hello, World!" : Blob,
           Array.toBlob([0, 1, 2, 3, 127, 128, 254, 255])
         ];
-        for (b in cases.vals()) {
+        for (b in cases.values()) {
           expect.option<Blob>(Base64.decode(Base64.encode(b)), blobToText, Blob.equal).equal(?b)
         }
       }

--- a/test/Iter.test.mo
+++ b/test/Iter.test.mo
@@ -19,7 +19,7 @@ suite(
         var z = 0;
 
         Iter.forEach<(Nat, Text)>(
-          Iter.enumerate(xs.vals()),
+          Iter.enumerate(xs.values()),
           func(i, x) {
             y := y # x;
             z += i
@@ -40,7 +40,7 @@ suite(
       "maps elements using provided function",
       func() {
         let isEven = func(x : Int) : Bool { x % 2 == 0 };
-        let _actual = Iter.map([1, 2, 3].vals(), isEven);
+        let _actual = Iter.map([1, 2, 3].values(), isEven);
         let actual = [var true, false, true];
         Iter.forEach<(Nat, Bool)>(
           Iter.enumerate(_actual),
@@ -63,7 +63,7 @@ suite(
       "filters elements using predicate",
       func() {
         let isOdd = func(x : Int) : Bool { x % 2 == 1 };
-        let _actual = Iter.filter([1, 2, 3].vals(), isOdd);
+        let _actual = Iter.filter([1, 2, 3].values(), isOdd);
         let actual = [var 0, 0];
         Iter.forEach<(Nat, Nat)>(
           Iter.enumerate(_actual),
@@ -79,7 +79,7 @@ suite(
   "filterMap",
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
-      let actual = Iter.filterMap(inputs.vals(), func(x) = if (x % 2 == 0) ?(x * 10) else null);
+      let actual = Iter.filterMap(inputs.values(), func(x) = if (x % 2 == 0) ?(x * 10) else null);
       expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4], [20, 40]));
@@ -92,7 +92,7 @@ suite(
   "flatten",
   func() {
     func mk(inputs : [[Nat]], expected : [Nat]) {
-      let actual = Iter.flatten(Iter.map(inputs.vals(), func(x) = x.values()));
+      let actual = Iter.flatten(Iter.map(inputs.values(), func(x) = x.values()));
       expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([[1, 2], [3], [4, 5, 6]], [1, 2, 3, 4, 5, 6]));
@@ -105,7 +105,7 @@ suite(
   "flatMap",
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
-      let actual = Iter.flatMap(inputs.vals(), func(x) = [x, x * 10].vals());
+      let actual = Iter.flatMap(inputs.values(), func(x) = [x, x * 10].values());
       expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3], [1, 10, 2, 20, 3, 30]));
@@ -117,7 +117,7 @@ suite(
   "take",
   func() {
     func mk(inputs : [Nat], n : Nat, expected : [Nat]) {
-      let actual = Iter.take(inputs.vals(), n);
+      let actual = Iter.take(inputs.values(), n);
       expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4, 5], 3, [1, 2, 3]));
@@ -132,7 +132,7 @@ suite(
   "drop",
   func() {
     func mk(inputs : [Nat], n : Nat, expected : [Nat]) {
-      let actual = Iter.drop(inputs.vals(), n);
+      let actual = Iter.drop(inputs.values(), n);
       expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4, 5], 3, [4, 5]));
@@ -147,7 +147,7 @@ suite(
   "takeWhile",
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
-      let actual = Iter.takeWhile(inputs.vals(), func(x) = x < 4);
+      let actual = Iter.takeWhile(inputs.values(), func(x) = x < 4);
       expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4, 5, 4, 3, 2, 1], [1, 2, 3]));
@@ -161,7 +161,7 @@ suite(
   "dropWhile",
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
-      let actual = Iter.dropWhile(inputs.vals(), func(x) = x < 4);
+      let actual = Iter.dropWhile(inputs.values(), func(x) = x < 4);
       expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4, 5, 4, 3, 2, 1], [4, 5, 4, 3, 2, 1]));
@@ -175,7 +175,7 @@ suite(
   "zip",
   func() {
     func mk(input1 : [Nat], input2 : [Nat], expected : [(Nat, Nat)]) {
-      let actual = Iter.zip(input1.vals(), input2.vals());
+      let actual = Iter.zip(input1.values(), input2.values());
       expect.array<(Nat, Nat)>(Iter.toArray(actual), Tuple2.makeToText<Nat, Nat>(Nat.toText, Nat.toText), Tuple2.makeEqual<Nat, Nat>(Nat.equal, Nat.equal)).equal(expected)
     };
     test("matched", func() = mk([1, 2, 3], [4, 5, 6], [(1, 4), (2, 5), (3, 6)]));
@@ -191,7 +191,7 @@ suite(
   "zipWith",
   func() {
     func mk(input1 : [Nat], input2 : [Nat], expected : [Nat]) {
-      let actual = Iter.zipWith(input1.vals(), input2.vals(), func(x, y) = x + y);
+      let actual = Iter.zipWith(input1.values(), input2.values(), func(x, y) = x + y);
       expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
     };
     test("matched", func() = mk([1, 2, 3], [4, 5, 6], [5, 7, 9]));
@@ -207,7 +207,7 @@ suite(
   "zip3",
   func() {
     func mk(input1 : [Nat], input2 : [Nat], input3 : [Nat], expected : [(Nat, Nat, Nat)]) {
-      let actual = Iter.zip3(input1.vals(), input2.vals(), input3.vals());
+      let actual = Iter.zip3(input1.values(), input2.values(), input3.values());
       expect.array<(Nat, Nat, Nat)>(Iter.toArray(actual), Tuple3.makeToText<Nat, Nat, Nat>(Nat.toText, Nat.toText, Nat.toText), Tuple3.makeEqual<Nat, Nat, Nat>(Nat.equal, Nat.equal, Nat.equal)).equal(expected)
     };
     test("matched", func() = mk([1, 2, 3], [4, 5, 6], [7, 8, 9], [(1, 4, 7), (2, 5, 8), (3, 6, 9)]));
@@ -224,7 +224,7 @@ suite(
   "zipWith3",
   func() {
     func mk(input1 : [Nat], input2 : [Nat], input3 : [Nat], expected : [Nat]) {
-      let actual = Iter.zipWith3(input1.vals(), input2.vals(), input3.vals(), func(x, y, z) = x + y + z);
+      let actual = Iter.zipWith3(input1.values(), input2.values(), input3.values(), func(x, y, z) = x + y + z);
       expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
     };
     test("matched", func() = mk([1, 2, 3], [4, 5, 6], [7, 8, 9], [12, 15, 18]));
@@ -321,7 +321,7 @@ suite(
       "converts iterator to array",
       func() {
         let expected = [1, 2, 3];
-        let actual = Iter.toArray(expected.vals());
+        let actual = Iter.toArray(expected.values());
         expect.nat(actual.size()).equal(expected.size());
         for (i in actual.keys()) {
           expect.nat(actual[i]).equal(expected[i])
@@ -338,7 +338,7 @@ suite(
       "converts iterator to var array",
       func() {
         let expected = [var 1, 2, 3];
-        let actual = Iter.toVarArray<Nat>(expected.vals());
+        let actual = Iter.toVarArray<Nat>(expected.values());
         expect.nat(actual.size()).equal(expected.size());
         for (i in actual.keys()) {
           expect.nat(actual[i]).equal(expected[i])
@@ -356,7 +356,7 @@ suite(
       func() {
         let input : [Nat] = [4, 3, 1, 2, 5];
         let expected : [Nat] = [1, 2, 3, 4, 5];
-        let actual = Iter.toArray(Iter.sort(input.vals(), Nat.compare));
+        let actual = Iter.toArray(Iter.sort(input.values(), Nat.compare));
         expect.array<Nat>(actual, Nat.toText, Nat.equal).equal(expected)
       }
     )
@@ -501,7 +501,7 @@ suite(
       "reverses elements in iterator",
       func() {
         let array1 = [1, 2, 3, 4];
-        let iter1 = Iter.reverse(array1.vals());
+        let iter1 = Iter.reverse(array1.values());
         assert (iter1.next() == ?4);
         assert (iter1.next() == ?3);
         assert (iter1.next() == ?2);
@@ -514,7 +514,7 @@ suite(
       "empty array remains empty",
       func() {
         let array2 = ([] : [Nat]);
-        let iter2 = Iter.reverse(array2.vals());
+        let iter2 = Iter.reverse(array2.values());
         assert (iter2.next() == null)
       }
     );
@@ -523,7 +523,7 @@ suite(
       "single element array remains unchanged",
       func() {
         let array3 = ['a'];
-        let iter3 = Iter.reverse(array3.vals());
+        let iter3 = Iter.reverse(array3.values());
         assert (iter3.next() == ?'a');
         assert (iter3.next() == null)
       }
@@ -551,7 +551,7 @@ suite(
       "returns correct size for various iterators",
       func() {
         expect.nat(Iter.size(Iter.empty<Nat>())).equal(0);
-        expect.nat(Iter.size([1, 2, 3].vals())).equal(3);
+        expect.nat(Iter.size([1, 2, 3].values())).equal(3);
 
         let boundedIter = object {
           var count = 0;
@@ -582,7 +582,7 @@ suite(
     test(
       "single element returns tuple with index 0",
       func() {
-        let singleEnum = Iter.enumerate(["a"].vals());
+        let singleEnum = Iter.enumerate(["a"].values());
         assert (singleEnum.next() == ?(0, "a"));
         assert (singleEnum.next() == null)
       }
@@ -591,7 +591,7 @@ suite(
     test(
       "multiple elements return tuples with increasing indices",
       func() {
-        let multiEnum = Iter.enumerate([10, 20, 30].vals());
+        let multiEnum = Iter.enumerate([10, 20, 30].values());
         assert (multiEnum.next() == ?(0, 10));
         assert (multiEnum.next() == ?(1, 20));
         assert (multiEnum.next() == ?(2, 30));
@@ -607,7 +607,7 @@ suite(
     test(
       "step of zero returns empty iterator",
       func() {
-        let step0 = Iter.step([1, 2, 3, 4, 5].vals(), 0);
+        let step0 = Iter.step([1, 2, 3, 4, 5].values(), 0);
         assert (step0.next() == null)
       }
     );
@@ -615,7 +615,7 @@ suite(
     test(
       "step of one returns all elements",
       func() {
-        let step1 = Iter.step([1, 2, 3].vals(), 1);
+        let step1 = Iter.step([1, 2, 3].values(), 1);
         assert (step1.next() == ?1);
         assert (step1.next() == ?2);
         assert (step1.next() == ?3);
@@ -626,7 +626,7 @@ suite(
     test(
       "step of two returns every other element",
       func() {
-        let step2 = Iter.step([1, 2, 3, 4, 5].vals(), 2);
+        let step2 = Iter.step([1, 2, 3, 4, 5].values(), 2);
         assert (step2.next() == ?1);
         assert (step2.next() == ?3);
         assert (step2.next() == ?5);
@@ -637,7 +637,7 @@ suite(
     test(
       "step larger than size returns first element only",
       func() {
-        let stepBig = Iter.step([1, 2, 3].vals(), 4);
+        let stepBig = Iter.step([1, 2, 3].values(), 4);
         assert (stepBig.next() == ?1);
         assert (stepBig.next() == null)
       }
@@ -659,7 +659,7 @@ suite(
     test(
       "left empty returns right iterator",
       func() {
-        let leftEmpty = Iter.concat(Iter.empty<Nat>(), [1, 2].vals());
+        let leftEmpty = Iter.concat(Iter.empty<Nat>(), [1, 2].values());
         assert (leftEmpty.next() == ?1);
         assert (leftEmpty.next() == ?2);
         assert (leftEmpty.next() == null)
@@ -669,7 +669,7 @@ suite(
     test(
       "right empty returns left iterator",
       func() {
-        let rightEmpty = Iter.concat([1, 2].vals(), Iter.empty());
+        let rightEmpty = Iter.concat([1, 2].values(), Iter.empty());
         assert (rightEmpty.next() == ?1);
         assert (rightEmpty.next() == ?2);
         assert (rightEmpty.next() == null)
@@ -679,7 +679,7 @@ suite(
     test(
       "concatenates two non-empty iterators",
       func() {
-        let fullConcat = Iter.concat([1, 2].vals(), [3, 4].vals());
+        let fullConcat = Iter.concat([1, 2].values(), [3, 4].values());
         assert (fullConcat.next() == ?1);
         assert (fullConcat.next() == ?2);
         assert (fullConcat.next() == ?3);
@@ -694,7 +694,7 @@ suite(
   "all",
   func() {
     func mk(inputs : [Nat], expected : Bool, rest : [Nat]) {
-      let iter = inputs.vals();
+      let iter = inputs.values();
       let actual = Iter.all(iter, func(x) = x % 2 == 0);
       expect.bool(actual).equal(expected);
       let remaining = Iter.toArray(iter);
@@ -710,7 +710,7 @@ suite(
   "any",
   func() {
     func mk(inputs : [Nat], expected : Bool, rest : [Nat]) {
-      let iter = inputs.vals();
+      let iter = inputs.values();
       let actual = Iter.any(iter, func(x) = x % 2 == 0);
       expect.bool(actual).equal(expected);
       let remaining = Iter.toArray(iter);
@@ -726,7 +726,7 @@ suite(
   "find",
   func() {
     func mk(inputs : [Nat], expected : ?Nat, rest : [Nat]) {
-      let iter = inputs.vals();
+      let iter = inputs.values();
       let actual = Iter.find(iter, func(x) = x % 2 == 0);
       expect.option(actual, Nat.toText, Nat.equal).equal(expected);
       let remaining = Iter.toArray(iter);
@@ -742,7 +742,7 @@ suite(
   "findIndex",
   func() {
     func mk(inputs : [Nat], expected : ?Nat, rest : [Nat]) {
-      let iter = inputs.vals();
+      let iter = inputs.values();
       let actual = Iter.findIndex(iter, func(x) = x % 2 == 0);
       expect.option(actual, Nat.toText, Nat.equal).equal(expected);
       let remaining = Iter.toArray(iter);
@@ -758,7 +758,7 @@ suite(
   "contains",
   func() {
     func mk(inputs : [Nat], x : Nat, expected : Bool, rest : [Nat]) {
-      let iter = inputs.vals();
+      let iter = inputs.values();
       let actual = Iter.contains(iter, Nat.equal, x);
       expect.bool(actual).equal(expected);
       let remaining = Iter.toArray(iter);
@@ -774,7 +774,7 @@ suite(
   "foldLeft",
   func() {
     func mk(inputs : [Text], expected : Text) {
-      let actual = Iter.foldLeft(inputs.vals(), "S", func(acc, x) = "(" # acc # x # ")");
+      let actual = Iter.foldLeft(inputs.values(), "S", func(acc, x) = "(" # acc # x # ")");
       expect.text(actual).equal(expected)
     };
     test("some", func() = mk(["A", "B", "C"], "(((SA)B)C)"));
@@ -786,7 +786,7 @@ suite(
   "foldRight",
   func() {
     func mk(inputs : [Text], expected : Text) {
-      let actual = Iter.foldRight(inputs.vals(), "S", func(x, acc) = "(" # x # acc # ")");
+      let actual = Iter.foldRight(inputs.values(), "S", func(x, acc) = "(" # x # acc # ")");
       expect.text(actual).equal(expected)
     };
     test("some", func() = mk(["A", "B", "C"], "(A(B(CS)))"));
@@ -798,7 +798,7 @@ suite(
   "reduce",
   func() {
     func mk(inputs : [Text], expected : ?Text) {
-      let actual = Iter.reduce(inputs.vals(), func(x, acc) = "(" # x # acc # ")");
+      let actual = Iter.reduce(inputs.values(), func(x, acc) = "(" # x # acc # ")");
       expect.option(actual, func(x : Text) : Text = x, Text.equal).equal(expected)
     };
     test("some", func() = mk(["A", "B", "C"], ?"((AB)C)"));
@@ -811,7 +811,7 @@ suite(
   "scanLeft",
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
-      let actual = Iter.scanLeft(inputs.vals(), 0, func(acc, x) = acc + x);
+      let actual = Iter.scanLeft(inputs.values(), 0, func(acc, x) = acc + x);
       expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4], [0, 1, 3, 6, 10]));
@@ -823,7 +823,7 @@ suite(
   "scanRight",
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
-      let actual = Iter.scanRight(inputs.vals(), 0, func(x, acc) = acc + x);
+      let actual = Iter.scanRight(inputs.values(), 0, func(x, acc) = acc + x);
       expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4], [0, 4, 7, 9, 10]));
@@ -847,7 +847,7 @@ suite(
   "max",
   func() {
     func mk(inputs : [Nat], expected : ?Nat) {
-      let actual = Iter.max(inputs.vals(), Nat.compare);
+      let actual = Iter.max(inputs.values(), Nat.compare);
       expect.option(actual, Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 2, 3], ?3));
@@ -859,7 +859,7 @@ suite(
   "min",
   func() {
     func mk(inputs : [Nat], expected : ?Nat) {
-      let actual = Iter.min(inputs.vals(), Nat.compare);
+      let actual = Iter.min(inputs.values(), Nat.compare);
       expect.option(actual, Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 1, 4], ?1));

--- a/test/List.test.mo
+++ b/test/List.test.mo
@@ -1109,7 +1109,7 @@ run(
 // Helper function to run tests
 func runTest(name : Text, test : (Nat) -> Bool) {
   let testSizes = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 100];
-  for (n in testSizes.vals()) {
+  for (n in testSizes.values()) {
     if (test(n)) {
       Debug.print("✅ " # name # " passed for n = " # Nat.toText(n))
     } else {
@@ -1404,7 +1404,7 @@ func testMapInPlace(n : Nat) : Bool {
 
 func testFlatMap(n : Nat) : Bool {
   let vec = List.fromArray<Nat>(Array.tabulate<Nat>(n, func(i) = i));
-  let flatMapped = List.flatMap<Nat, Nat>(vec, func(x) = [x, x].vals());
+  let flatMapped = List.flatMap<Nat, Nat>(vec, func(x) = [x, x].values());
 
   let expected = List.fromArray<Nat>(Array.tabulate<Nat>(2 * n, func(i) = i / 2));
   List.equal(flatMapped, expected, Nat.equal)
@@ -1559,7 +1559,7 @@ func testDeduplicate(n : Nat) : Bool {
     List.fromArray<Nat>([1, 1, 2, 3])
   ];
 
-  for (list in lists.vals()) {
+  for (list in lists.values()) {
     List.deduplicate(list, Nat.equal);
     if (not List.equal(list, List.fromArray<Nat>([1, 2, 3]), Nat.equal)) {
       Debug.print("Deduplicate failed for " # List.toText(list, Nat.toText));
@@ -1819,7 +1819,7 @@ func testJoin(n : Nat) : Bool {
   let iter = Array.tabulate(
     n,
     func(i) = List.fromArray<Nat>(Array.tabulate<Nat>(i + 1, func(j) = j))
-  ).vals();
+  ).values();
   let flattened = List.join(iter);
   let expectedSize = (n * (n + 1)) / 2;
 

--- a/test/Map.test.mo
+++ b/test/Map.test.mo
@@ -844,10 +844,10 @@ run(
           let copy = smallMap();
           let clone = Map.clone(original);
           let keys = Iter.toArray(Map.keys(original));
-          for (key in keys.vals()) {
+          for (key in keys.values()) {
             Map.add(original, Nat.compare, key, "X")
           };
-          for (key in keys.vals()) {
+          for (key in keys.values()) {
             assert Map.get(clone, Nat.compare, key) == Map.get(copy, Nat.compare, key)
           };
           Map.size(clone)

--- a/test/Queue.test.mo
+++ b/test/Queue.test.mo
@@ -289,7 +289,7 @@ suite(
     test(
       "pop front",
       func() {
-        let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+        let queue = Queue.fromIter<Nat>([1, 2, 3].values());
         let results = [
           Queue.popFront(queue),
           Queue.popFront(queue),
@@ -304,7 +304,7 @@ suite(
     test(
       "pop back",
       func() {
-        let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+        let queue = Queue.fromIter<Nat>([1, 2, 3].values());
         let results = [
           Queue.popBack(queue),
           Queue.popBack(queue),
@@ -319,7 +319,7 @@ suite(
     test(
       "mixed pop",
       func() {
-        let queue = Queue.fromIter<Nat>([1, 2, 3, 4].vals());
+        let queue = Queue.fromIter<Nat>([1, 2, 3, 4].values());
         let results = [
           Queue.popFront(queue),
           Queue.popBack(queue),
@@ -340,7 +340,7 @@ suite(
     test(
       "map",
       func() {
-        let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+        let queue = Queue.fromIter<Nat>([1, 2, 3].values());
         let mapped = Queue.map(queue, Nat.toText);
         assert Iter.toArray(Queue.values(mapped)) == ["1", "2", "3"]
       }
@@ -349,7 +349,7 @@ suite(
     test(
       "filter",
       func() {
-        let queue = Queue.fromIter<Nat>([1, 2, 3, 4].vals());
+        let queue = Queue.fromIter<Nat>([1, 2, 3, 4].values());
         let filtered = Queue.filter(queue, func n = n % 2 == 0);
         assert Iter.toArray(Queue.values(filtered)) == [2, 4]
       }
@@ -358,7 +358,7 @@ suite(
     test(
       "filter map",
       func() {
-        let queue = Queue.fromIter<Nat>([1, 2, 3, 4].vals());
+        let queue = Queue.fromIter<Nat>([1, 2, 3, 4].values());
         let result = Queue.filterMap(
           queue,
           func n = if (n % 2 == 0) ?Nat.toText(n) else null
@@ -370,7 +370,7 @@ suite(
     test(
       "for each",
       func() {
-        let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+        let queue = Queue.fromIter<Nat>([1, 2, 3].values());
         var sum = 0;
         Queue.forEach<Nat>(queue, func n { sum += n });
         assert sum == 6
@@ -385,7 +385,7 @@ suite(
     test(
       "all true",
       func() {
-        let queue = Queue.fromIter<Nat>([2, 4, 6].vals());
+        let queue = Queue.fromIter<Nat>([2, 4, 6].values());
         assert Queue.all<Nat>(queue, func n = n % 2 == 0)
       }
     );
@@ -393,7 +393,7 @@ suite(
     test(
       "all false",
       func() {
-        let queue = Queue.fromIter<Nat>([2, 3, 4].vals());
+        let queue = Queue.fromIter<Nat>([2, 3, 4].values());
         assert not Queue.all<Nat>(queue, func n = n % 2 == 0)
       }
     );
@@ -401,7 +401,7 @@ suite(
     test(
       "any true",
       func() {
-        let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+        let queue = Queue.fromIter<Nat>([1, 2, 3].values());
         assert Queue.any<Nat>(queue, func n = n % 2 == 0)
       }
     );
@@ -409,7 +409,7 @@ suite(
     test(
       "any false",
       func() {
-        let queue = Queue.fromIter<Nat>([1, 3, 5].vals());
+        let queue = Queue.fromIter<Nat>([1, 3, 5].values());
         assert not Queue.any<Nat>(queue, func n = n % 2 == 0)
       }
     )
@@ -458,7 +458,7 @@ suite(
     test(
       "multiple elements to pure",
       func() {
-        let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+        let queue = Queue.fromIter<Nat>([1, 2, 3].values());
         let pureQueue = Queue.toPure(queue);
         assert Iter.toArray(PureQueue.values(pureQueue)) == [1, 2, 3]
       }
@@ -479,7 +479,7 @@ suite(
     test(
       "round trip mutable to pure to mutable",
       func() {
-        let original = Queue.fromIter<Nat>([1, 2, 3].vals());
+        let original = Queue.fromIter<Nat>([1, 2, 3].values());
         let pureQueue = Queue.toPure(original);
         let roundTrip = Queue.fromPure<Nat>(pureQueue);
         assert Iter.toArray(Queue.values(roundTrip)) == [1, 2, 3]

--- a/test/Set.test.mo
+++ b/test/Set.test.mo
@@ -945,10 +945,10 @@ run(
           let copy = smallSet();
           let clone = Set.clone(original);
           let keys = Iter.toArray(Set.values(original));
-          for (key in keys.vals()) {
+          for (key in keys.values()) {
             Set.remove(original, Nat.compare, key)
           };
-          for (key in keys.vals()) {
+          for (key in keys.values()) {
             assert Set.contains(clone, Nat.compare, key) == Set.contains(copy, Nat.compare, key)
           };
           Set.size(clone)

--- a/test/Stack.test.mo
+++ b/test/Stack.test.mo
@@ -105,7 +105,7 @@ suite(
     test(
       "clear empties stack",
       func() {
-        let s = Stack.fromIter<Nat>([1, 2, 3].vals());
+        let s = Stack.fromIter<Nat>([1, 2, 3].values());
         Stack.clear(s);
         expect.bool(Stack.isEmpty(s)).isTrue()
       }
@@ -114,7 +114,7 @@ suite(
     test(
       "clone creates independent copy",
       func() {
-        let original = Stack.fromIter<Nat>([1, 2, 3].vals());
+        let original = Stack.fromIter<Nat>([1, 2, 3].values());
         let copy = Stack.clone(original);
         ignore Stack.pop(original);
         expect.bool(Stack.size(copy) == 3 and Stack.peek(copy) == ?3).isTrue()
@@ -129,7 +129,7 @@ suite(
     test(
       "contains finds element",
       func() {
-        let s = Stack.fromIter<Nat>([1, 2, 3].vals());
+        let s = Stack.fromIter<Nat>([1, 2, 3].values());
         expect.bool(Stack.contains(s, Nat.equal, 2)).isTrue()
       }
     );
@@ -137,7 +137,7 @@ suite(
     test(
       "get retrieves correct element",
       func() {
-        let s = Stack.fromIter<Nat>([1, 2, 3].vals());
+        let s = Stack.fromIter<Nat>([1, 2, 3].values());
         expect.bool(Stack.get(s, 1) == ?2).isTrue()
       }
     );
@@ -145,7 +145,7 @@ suite(
     test(
       "values iterates in LIFO order",
       func() {
-        let s = Stack.fromIter<Nat>([1, 2, 3].vals());
+        let s = Stack.fromIter<Nat>([1, 2, 3].values());
         expect.array(Iter.toArray(Stack.values(s)), Nat.toText, Nat.equal).equal([3, 2, 1])
       }
     )
@@ -158,7 +158,7 @@ suite(
     test(
       "reverse changes order",
       func() {
-        let s = Stack.fromIter<Nat>([1, 2, 3].vals());
+        let s = Stack.fromIter<Nat>([1, 2, 3].values());
         Stack.reverse(s);
         expect.array(Iter.toArray(Stack.values(s)), Nat.toText, Nat.equal).equal([1, 2, 3])
       }
@@ -167,7 +167,7 @@ suite(
     test(
       "map transforms elements",
       func() {
-        let s = Stack.fromIter<Nat>([1, 2, 3].vals());
+        let s = Stack.fromIter<Nat>([1, 2, 3].values());
         let mapped = Stack.map<Nat, Nat>(s, func(x) { x + 1 });
         expect.array(Iter.toArray(Stack.values(mapped)), Nat.toText, Nat.equal).equal([4, 3, 2])
       }
@@ -176,7 +176,7 @@ suite(
     test(
       "filter keeps matching elements",
       func() {
-        let s = Stack.fromIter<Nat>([1, 2, 3, 4].vals());
+        let s = Stack.fromIter<Nat>([1, 2, 3, 4].values());
         let evens = Stack.filter(s, func(x) { x % 2 == 0 });
         expect.array(Iter.toArray(Stack.values(evens)), Nat.toText, Nat.equal).equal([4, 2])
       }
@@ -185,7 +185,7 @@ suite(
     test(
       "filterMap combines map and filter",
       func() {
-        let s = Stack.fromIter<Nat>([1, 2, 3, 4].vals());
+        let s = Stack.fromIter<Nat>([1, 2, 3, 4].values());
         let evenDoubled = Stack.filterMap<Nat, Nat>(
           s,
           func(x) {
@@ -204,7 +204,7 @@ suite(
     test(
       "all true when all match",
       func() {
-        let s = Stack.fromIter<Nat>([2, 4, 6].vals());
+        let s = Stack.fromIter<Nat>([2, 4, 6].values());
         expect.bool(Stack.all<Nat>(s, func(x) { x % 2 == 0 })).isTrue()
       }
     );
@@ -212,7 +212,7 @@ suite(
     test(
       "all false when any doesn't match",
       func() {
-        let s = Stack.fromIter<Nat>([2, 3, 4].vals());
+        let s = Stack.fromIter<Nat>([2, 3, 4].values());
         expect.bool(Stack.all<Nat>(s, func(x) { x % 2 == 0 })).isFalse()
       }
     );
@@ -220,7 +220,7 @@ suite(
     test(
       "any true when one matches",
       func() {
-        let s = Stack.fromIter<Nat>([1, 2, 3].vals());
+        let s = Stack.fromIter<Nat>([1, 2, 3].values());
         expect.bool(Stack.any<Nat>(s, func(x) { x % 2 == 0 })).isTrue()
       }
     );
@@ -228,7 +228,7 @@ suite(
     test(
       "any false when none match",
       func() {
-        let s = Stack.fromIter<Nat>([1, 3, 5].vals());
+        let s = Stack.fromIter<Nat>([1, 3, 5].values());
         expect.bool(Stack.any<Nat>(s, func(x) { x % 2 == 0 })).isFalse()
       }
     )
@@ -241,8 +241,8 @@ suite(
     test(
       "equal returns true for identical stacks",
       func() {
-        let s1 = Stack.fromIter<Nat>([1, 2, 3].vals());
-        let s2 = Stack.fromIter<Nat>([1, 2, 3].vals());
+        let s1 = Stack.fromIter<Nat>([1, 2, 3].values());
+        let s2 = Stack.fromIter<Nat>([1, 2, 3].values());
         expect.bool(Stack.equal(s1, s2, Nat.equal)).isTrue()
       }
     );
@@ -250,8 +250,8 @@ suite(
     test(
       "equal returns false for different stacks",
       func() {
-        let s1 = Stack.fromIter<Nat>([1, 2, 3].vals());
-        let s2 = Stack.fromIter<Nat>([1, 2, 4].vals());
+        let s1 = Stack.fromIter<Nat>([1, 2, 3].values());
+        let s2 = Stack.fromIter<Nat>([1, 2, 4].values());
         expect.bool(Stack.equal(s1, s2, Nat.equal)).isFalse()
       }
     );
@@ -259,8 +259,8 @@ suite(
     test(
       "compare orders correctly",
       func() {
-        let s1 = Stack.fromIter<Nat>([1, 2].vals());
-        let s2 = Stack.fromIter<Nat>([1, 2, 3].vals());
+        let s1 = Stack.fromIter<Nat>([1, 2].values());
+        let s2 = Stack.fromIter<Nat>([1, 2, 3].values());
         expect.bool(Stack.compare(s1, s2, Nat.compare) == #less).isTrue()
       }
     )
@@ -273,7 +273,7 @@ suite(
     test(
       "toText formats correctly",
       func() {
-        let s = Stack.fromIter<Nat>([1, 2, 3].vals());
+        let s = Stack.fromIter<Nat>([1, 2, 3].values());
         expect.text(Stack.toText(s, Nat.toText)).equal("Stack[3, 2, 1]")
       }
     )

--- a/test/Text.test.mo
+++ b/test/Text.test.mo
@@ -31,7 +31,7 @@ func optTextT(ot : ?Text) : T.TestableItem<?Text> = T.optional(T.textTestable, o
 
 // TODO: generalize and move to Iter.mo
 func iterT(c : [Char]) : T.TestableItem<Iter.Iter<Char>> = {
-  item = c.vals();
+  item = c.values();
   display = Text.fromIter; // not this will only print the remainder of cs1 below
   equals = func(cs1 : Iter.Iter<Char>, cs2 : Iter.Iter<Char>) : Bool {
     loop {
@@ -46,7 +46,7 @@ func iterT(c : [Char]) : T.TestableItem<Iter.Iter<Char>> = {
 
 // TODO: generalize and move to Iter.mo
 func textIterT(c : [Text]) : T.TestableItem<Iter.Iter<Text>> = {
-  item = c.vals();
+  item = c.values();
   display = func(ts : Iter.Iter<Text>) : Text { Text.join(ts, ",") };
   // not this will only print the remainder of cs1 below
   equals = func(ts1 : Iter.Iter<Text>, ts2 : Iter.Iter<Text>) : Bool {
@@ -144,7 +144,7 @@ run(
         let a = Array.tabulate(1000, func i = Nat32.toChar(65 +% Nat32.fromIntWrap(i % 26)));
         test(
           "fromIter-2",
-          Text.toIter(Text.join(Array.map(a, Char.toText).vals(), "")),
+          Text.toIter(Text.join(Array.map(a, Char.toText).values(), "")),
           M.equals(iterT a)
         )
       }
@@ -158,25 +158,25 @@ run(
     [
       test(
         "fromIter-0",
-        Text.fromIter(([].vals())),
+        Text.fromIter(([].values())),
         M.equals(T.text(""))
       ),
       test(
         "fromIter-1",
-        Text.fromIter((['a'].vals())),
+        Text.fromIter((['a'].values())),
         M.equals(T.text "a")
       ),
       test(
         "fromIter-2",
-        Text.fromIter((['a', 'b', 'c'].vals())),
+        Text.fromIter((['a', 'b', 'c'].values())),
         M.equals(T.text "abc")
       ),
       do {
         let a = Array.tabulate(1000, func i = Nat32.toChar(65 +% Nat32.fromIntWrap(i % 26)));
         test(
           "fromIter-3",
-          Text.fromIter(a.vals()),
-          M.equals(T.text(Text.join(Array.map(a, Char.toText).vals(), "")))
+          Text.fromIter(a.values()),
+          M.equals(T.text(Text.join(Array.map(a, Char.toText).values(), "")))
         )
       }
     ]
@@ -265,35 +265,35 @@ run(
     [
       test(
         "join-0",
-        Text.join(["", ""].vals(), ""),
+        Text.join(["", ""].values(), ""),
         M.equals(T.text(""))
       ),
       test(
         "join-1",
-        Text.join(["", "b"].vals(), ""),
+        Text.join(["", "b"].values(), ""),
         M.equals(T.text "b")
       ),
       test(
         "join-2",
-        Text.join(["a", "bb", "ccc", "dddd"].vals(), ""),
+        Text.join(["a", "bb", "ccc", "dddd"].values(), ""),
         M.equals(T.text "abbcccdddd")
       ),
       do {
         let a = Array.tabulate(1000, func i = Nat32.toChar(65 +% Nat32.fromIntWrap(i % 26)));
         test(
           "join-3",
-          Text.join(Array.map(a, Char.toText).vals(), ""),
-          M.equals(T.text(Text.fromIter(a.vals())))
+          Text.join(Array.map(a, Char.toText).values(), ""),
+          M.equals(T.text(Text.fromIter(a.values())))
         )
       },
       test(
         "join-4",
-        Text.join([].vals(), ""),
+        Text.join([].values(), ""),
         M.equals(T.text "")
       ),
       test(
         "join-5",
-        Text.join(["aaa"].vals(), ""),
+        Text.join(["aaa"].values(), ""),
         M.equals(T.text "aaa")
       )
     ]
@@ -306,35 +306,35 @@ run(
     [
       test(
         "join-0",
-        Text.join(["", ""].vals(), ","),
+        Text.join(["", ""].values(), ","),
         M.equals(T.text(","))
       ),
       test(
         "join-1",
-        Text.join(["", "b"].vals(), ","),
+        Text.join(["", "b"].values(), ","),
         M.equals(T.text ",b")
       ),
       test(
         "join-2",
-        Text.join(["a", "bb", "ccc", "dddd"].vals(), ","),
+        Text.join(["a", "bb", "ccc", "dddd"].values(), ","),
         M.equals(T.text "a,bb,ccc,dddd")
       ),
       do {
         let a = Array.tabulate(1000, func i = Nat32.toChar(65 +% Nat32.fromIntWrap(i % 26)));
         test(
           "join-3",
-          Text.join(Array.map(a, Char.toText).vals(), ""),
-          M.equals(T.text(Text.fromIter(a.vals())))
+          Text.join(Array.map(a, Char.toText).values(), ""),
+          M.equals(T.text(Text.fromIter(a.values())))
         )
       },
       test(
         "join-4",
-        Text.join([].vals(), ","),
+        Text.join([].values(), ","),
         M.equals(T.text "")
       ),
       test(
         "join-5",
-        Text.join(["aaa"].vals(), ","),
+        Text.join(["aaa"].values(), ","),
         M.equals(T.text "aaa")
       )
     ]
@@ -377,7 +377,7 @@ run(
       ),
       do {
         let a = Array.tabulate(1000, func _ = "abc");
-        let t = Text.join(a.vals(), ";");
+        let t = Text.join(a.values(), ";");
         test(
           "split-char-large",
           Text.split(t, #char ';'),
@@ -386,7 +386,7 @@ run(
       },
       do {
         let a = Array.tabulate(100000, func _ = "abc");
-        let t = Text.join(a.vals(), ";");
+        let t = Text.join(a.values(), ";");
         test(
           "split-char-very-large",
           Text.split(t, #char ';'),
@@ -435,7 +435,7 @@ do {
         ),
         do {
           let a = Array.tabulate(1000, func _ = "abc");
-          let t = Text.join(a.vals(), ";");
+          let t = Text.join(a.values(), ";");
           test(
             "split-pred-large",
             Text.split(t, pat),
@@ -444,7 +444,7 @@ do {
         },
         do {
           let a = Array.tabulate(10000, func _ = "abc");
-          let t = Text.join(a.vals(), ";");
+          let t = Text.join(a.values(), ";");
           test(
             "split-pred-very-large",
             Text.split(t, pat),
@@ -494,7 +494,7 @@ do {
         ),
         do {
           let a = Array.tabulate(1000, func _ = "abc");
-          let t = Text.join(a.vals(), "PAT");
+          let t = Text.join(a.values(), "PAT");
           test(
             "split-pat-large",
             Text.split(t, pat),
@@ -503,7 +503,7 @@ do {
         },
         do {
           let a = Array.tabulate(10000, func _ = "abc");
-          let t = Text.join(a.vals(), "PAT");
+          let t = Text.join(a.values(), "PAT");
           test(
             "split-pat-very-large",
             Text.split(t, pat),
@@ -551,7 +551,7 @@ run(
       ),
       do {
         let a = Array.tabulate(1000, func _ = "abc");
-        let t = Text.join(a.vals(), ";;");
+        let t = Text.join(a.values(), ";;");
         test(
           "tokens-char-large",
           Text.tokens(t, #char ';'),
@@ -560,7 +560,7 @@ run(
       },
       do {
         let a = Array.tabulate(100000, func _ = "abc");
-        let t = Text.join(a.vals(), ";;");
+        let t = Text.join(a.values(), ";;");
         test(
           "tokens-char-very-large",
           Text.tokens(t, #char ';'),

--- a/test/VarArray.test.mo
+++ b/test/VarArray.test.mo
@@ -331,19 +331,19 @@ let suite = Suite.suite(
     ),
     Suite.test(
       "flatMap",
-      VarArray.flatMap<Int, Int>([var 0, 1, 2], func x = [x, -x].vals()),
+      VarArray.flatMap<Int, Int>([var 0, 1, 2], func x = [x, -x].values()),
       M.equals(varArray<Int>(T.intTestable, [var 0, 0, 1, -1, 2, -2]))
     ),
     Suite.test(
       "flatMap empty",
-      VarArray.flatMap<Int, Int>([var], func x = [x, -x].vals()),
+      VarArray.flatMap<Int, Int>([var], func x = [x, -x].values()),
       M.equals(varArray<Int>(T.intTestable, [var]))
     ),
     Suite.test(
       "flatMap mix",
       VarArray.flatMap<Nat, Nat>(
         [var 1, 2, 1, 2, 3],
-        func n = VarArray.tabulate<Nat>(n, func i = i).vals()
+        func n = VarArray.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(varArray<Nat>(T.natTestable, [var 0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -351,7 +351,7 @@ let suite = Suite.suite(
       "flatMap mix empty right",
       VarArray.flatMap<Nat, Nat>(
         [var 0, 1, 2, 0, 1, 2, 3, 0],
-        func n = VarArray.tabulate<Nat>(n, func i = i).vals()
+        func n = VarArray.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(varArray<Nat>(T.natTestable, [var 0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -359,7 +359,7 @@ let suite = Suite.suite(
       "flatMap mix empties right",
       VarArray.flatMap<Nat, Nat>(
         [var 0, 1, 2, 0, 1, 2, 3, 0, 0, 0],
-        func n = VarArray.tabulate<Nat>(n, func i = i).vals()
+        func n = VarArray.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(varArray<Nat>(T.natTestable, [var 0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -367,7 +367,7 @@ let suite = Suite.suite(
       "flatMap mix empty left",
       VarArray.flatMap<Nat, Nat>(
         [var 0, 1, 2, 0, 1, 2, 3],
-        func n = VarArray.tabulate<Nat>(n, func i = i).vals()
+        func n = VarArray.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(varArray<Nat>(T.natTestable, [var 0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -375,7 +375,7 @@ let suite = Suite.suite(
       "flatMap mix empties left",
       VarArray.flatMap<Nat, Nat>(
         [var 0, 0, 0, 1, 2, 0, 1, 2, 3],
-        func n = VarArray.tabulate<Nat>(n, func i = i).vals()
+        func n = VarArray.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(varArray<Nat>(T.natTestable, [var 0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -383,7 +383,7 @@ let suite = Suite.suite(
       "flatMap mix empties middle",
       VarArray.flatMap<Nat, Nat>(
         [var 0, 1, 2, 0, 0, 0, 1, 2, 3],
-        func n = VarArray.tabulate<Nat>(n, func i = i).vals()
+        func n = VarArray.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(varArray<Nat>(T.natTestable, [var 0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -391,7 +391,7 @@ let suite = Suite.suite(
       "flatMap mix empties",
       VarArray.flatMap<Nat, Nat>(
         [var 0, 0, 0],
-        func n = VarArray.tabulate<Nat>(n, func i = i).vals()
+        func n = VarArray.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(varArray<Nat>(T.natTestable, [var]))
     ),
@@ -399,7 +399,7 @@ let suite = Suite.suite(
       "flatMap mix empty",
       VarArray.flatMap<Nat, Nat>(
         [var],
-        func n = VarArray.tabulate<Nat>(n, func i = i).vals()
+        func n = VarArray.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(varArray<Nat>(T.natTestable, [var]))
     ),

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -1663,7 +1663,7 @@ Test.suite(
   "join",
   func() {
     func t(input : [[Nat]], expected : [Nat]) : () -> () = func() {
-      let inputIter = Iter.map(input.vals(), func x = List.fromArray(x));
+      let inputIter = Iter.map(input.values(), func x = List.fromArray(x));
       let result = List.join(inputIter);
       Test.expect.array(List.toArray(result), Nat.toText, Nat.equal).equal(expected)
     };
@@ -1677,7 +1677,7 @@ Test.suite(
   "flatten",
   func() {
     func t(input : [[Nat]], expected : [Nat]) : () -> () = func() {
-      let inputList = List.fromIter(Iter.map(input.vals(), func x = List.fromArray(x)));
+      let inputList = List.fromIter(Iter.map(input.values(), func x = List.fromArray(x)));
       let result = List.flatten(inputList);
       Test.expect.array(List.toArray(result), Nat.toText, Nat.equal).equal(expected)
     };

--- a/test/pure/Map.prop.test.mo
+++ b/test/pure/Map.prop.test.mo
@@ -59,7 +59,7 @@ func mapGen(samples_number : Nat, size : Nat, range : (Nat, Nat)) : Iter.Iter<Ma
       if (n > samples_number) {
         null
       } else {
-        ?Map.fromIter(Random.nextEntries(range, size).vals(), c)
+        ?Map.fromIter(Random.nextEntries(range, size).values(), c)
       }
     }
   }

--- a/test/pure/Map.test.mo
+++ b/test/pure/Map.test.mo
@@ -35,7 +35,7 @@ func insert(rbTree : Map.Map<Nat, Text>, key : Nat) : Map.Map<Nat, Text> {
 };
 
 func getAll(rbTree : Map.Map<Nat, Text>, keys : [Nat]) {
-  for (key in keys.vals()) {
+  for (key in keys.values()) {
     let value = Map.get(rbTree, Nat.compare, key);
     assert (value == ?debug_show (key))
   }

--- a/test/pure/Queue.test.mo
+++ b/test/pure/Queue.test.mo
@@ -384,7 +384,7 @@ suite(
   }
 );
 
-queue := Queue.filter<Nat>(Queue.fromIter([1, 2, 3, 4, 5].vals()), func n = n < 3);
+queue := Queue.filter<Nat>(Queue.fromIter([1, 2, 3, 4, 5].values()), func n = n < 3);
 
 suite(
   "filter invariants",

--- a/test/pure/RealTimeQueue.test.mo
+++ b/test/pure/RealTimeQueue.test.mo
@@ -387,7 +387,7 @@ suite(
   }
 );
 
-queue := Queue.filter<Nat>(Queue.fromIter([1, 2, 3, 4, 5].vals()), func n = n < 3);
+queue := Queue.filter<Nat>(Queue.fromIter([1, 2, 3, 4, 5].values()), func n = n < 3);
 
 suite(
   "filter invariants",
@@ -595,7 +595,7 @@ suite(
       "all",
       func() {
         let testAll = func(testElements : [Nat]) {
-          let q = Queue.fromIter(testElements.vals());
+          let q = Queue.fromIter(testElements.values());
           expect.bool(Queue.all<Nat>(q, func n = n > 0)).isTrue();
           expect.bool(Queue.all<Nat>(q, func n = n < 3)).isFalse()
         };
@@ -612,7 +612,7 @@ suite(
       "filterMap",
       func() {
         let testFilterMap = func(testElements : [Nat]) {
-          let q = Queue.fromIter(testElements.vals());
+          let q = Queue.fromIter(testElements.values());
           let mapped = Queue.filterMap(
             q,
             func n = if (n % 2 == 0) ?Nat.toText(n) else null
@@ -637,7 +637,7 @@ suite(
       "forEach",
       func() {
         let testForEach = func(testElements : [Nat]) {
-          let q = Queue.fromIter(testElements.vals());
+          let q = Queue.fromIter(testElements.values());
           var result = "";
           Queue.forEach<Nat>(
             q,
@@ -661,7 +661,7 @@ suite(
       "toText",
       func() {
         let testToText = func(testElements : [Nat]) {
-          let q = Queue.fromIter(testElements.vals());
+          let q = Queue.fromIter(testElements.values());
           expect.text(Queue.toText(q, Nat.toText)).equal("RealTimeQueue" # Array.toText<Nat>(testElements, Nat.toText))
         };
         testToText([]);
@@ -678,7 +678,7 @@ suite(
       "size",
       func() {
         let testSize = func(testElements : [Nat]) {
-          let q = Queue.fromIter(testElements.vals());
+          let q = Queue.fromIter(testElements.values());
           expect.nat(Queue.size(q)).equal(testElements.size())
         };
         testSize([]);
@@ -695,7 +695,7 @@ suite(
       "contains",
       func() {
         let testContains = func(testElements : [Nat]) {
-          let q = Queue.fromIter(testElements.vals());
+          let q = Queue.fromIter(testElements.values());
           let alwaysThere = 1;
           let neverThere = 123;
           expect.bool(Queue.contains(q, Nat.equal, alwaysThere)).equal(Array.find<Nat>(testElements, func n = Nat.equal(n, alwaysThere)) != null);
@@ -715,7 +715,7 @@ suite(
       "any",
       func() {
         let testAny = func(testElements : [Nat]) {
-          let q = Queue.fromIter(testElements.vals());
+          let q = Queue.fromIter(testElements.values());
           expect.bool(Queue.any<Nat>(q, func n = n > 2)).equal(Array.any<Nat>(testElements, func n = n > 2));
           expect.bool(Queue.any<Nat>(q, func n = n > 3)).equal(Array.any<Nat>(testElements, func n = n > 3))
         };
@@ -734,7 +734,7 @@ suite(
       "map",
       func() {
         let testMap = func(testElements : [Nat]) {
-          let q = Queue.fromIter(testElements.vals());
+          let q = Queue.fromIter(testElements.values());
           let mapped = Queue.map(q, func n = n * 2);
           expect.array(
             Iter.toArray(Queue.values(mapped)),
@@ -756,7 +756,7 @@ suite(
       "reverse",
       func() {
         let testReverse = func(testElements : [Nat]) {
-          let q = Queue.fromIter(testElements.vals());
+          let q = Queue.fromIter(testElements.values());
           let reversed = Queue.reverse(q);
           expect.array(
             Iter.toArray(Queue.values(reversed)),
@@ -779,8 +779,8 @@ suite(
       "compare",
       func() {
         let testCompare = func(testElements1 : [Nat], testElements2 : [Nat]) {
-          let q1 = Queue.fromIter(testElements1.vals());
-          let q2 = Queue.fromIter(testElements2.vals());
+          let q1 = Queue.fromIter(testElements1.values());
+          let q2 = Queue.fromIter(testElements2.values());
           expect.bool(Queue.compare(q1, q2, Nat.compare) == Array.compare<Nat>(testElements1, testElements2, Nat.compare)).isTrue()
         };
 
@@ -860,9 +860,9 @@ suite(
           q := Queue.pushBack(q, i + 100)
         };
         // Mixed operations
-        expect.option(Queue.popFront(q), frontToText, frontEqual).equal(?(4, Queue.fromIter([3, 2, 1, 0, 100, 101, 102, 103, 104].vals())));
+        expect.option(Queue.popFront(q), frontToText, frontEqual).equal(?(4, Queue.fromIter([3, 2, 1, 0, 100, 101, 102, 103, 104].values())));
         q := Queue.pushBack(q, 200);
-        expect.option(Queue.popBack(q), backToText, backEqual).equal(?(Queue.fromIter([4, 3, 2, 1, 0, 100, 101, 102, 103, 104].vals()), 200));
+        expect.option(Queue.popBack(q), backToText, backEqual).equal(?(Queue.fromIter([4, 3, 2, 1, 0, 100, 101, 102, 103, 104].values()), 200));
         q := Queue.pushFront(q, 300);
         // Verify order is maintained
         expect.array(

--- a/test/pure/Set.prop.test.mo
+++ b/test/pure/Set.prop.test.mo
@@ -60,7 +60,7 @@ func setGenN(samples_number : Nat, size : Nat, range : (Nat, Nat), chunkSize : N
         ?Array.tabulate<Set.Set<Nat>>(
           chunkSize,
           func _ = Set.fromIter(
-            Random.nextEntries(range, size).vals(),
+            Random.nextEntries(range, size).values(),
             c
           )
         )

--- a/test/pure/Set.test.mo
+++ b/test/pure/Set.test.mo
@@ -41,7 +41,7 @@ func concatenateKeys2(accum : Text, key : Nat) : Text {
 };
 
 func containsAll(set : Set.Set<Nat>, elems : [Nat]) {
-  for (elem in elems.vals()) {
+  for (elem in elems.values()) {
     assert (Set.contains(set, Nat.compare, elem))
   }
 };


### PR DESCRIPTION
## Summary

The Motoko built-in iterator method `.vals()` on arrays and blobs is deprecated in favour of `.values()`. This PR replaces every remaining use of `.vals()` in `src`, `test`, and `bench` (including doc-comment examples) with `.values()`.

Pinned toolchain `moc 1.8.0` defines both names with identical types and semantics (`vals`/`values` in `array_obj`/`blob_obj`), so this is a pure naming change with no behavior difference.

## Changes

- `src/`: replace `.vals()` call sites and doc examples (Array, Iter, List, Principal, Queue, Set, Text, VarArray, pure/List)
- `test/`, `bench/`: replace `.vals()` calls in tests and benchmarks
- `Changelog.md`: entry under `## Next`

## Verification

- `npm run test:mops` — 630 passed, 0 failed
- `npm run test:ts` — passed
- `npm run validate:docs` — 1349 passed, 0 failed, 0 skipped
- `npm run validate:changelog`, `validate:version`, `validate:api`, `format:check`, `check:orphans` — all green
- `rg '\.vals'` repo-wide (excluding `node_modules`/`.mops`/`docs`) — zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
