### PR TITLE
ci: enforce M0236 in doc snippets (bump pinned moc to 1.9.0)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,5 @@
 ## Next
-* Enforce `M0236` (suggest contextual dot notation) in `validate:docs` doc snippets and bump the pinned `moc` toolchain to 1.9.0, which ships the check — doc examples now fail validation if a module-function call could be written with dot notation (e.g. `Map.get(map, k, Nat.compare)` → `map.get(k)`).
+* Enforce `M0236` (suggest contextual dot notation) in `validate:docs` doc snippets and bump the pinned `moc` toolchain to 1.16.0, which ships the check — doc examples now fail validation if a module-function call could be written with dot notation (e.g. `Map.get(map, k, Nat.compare)` → `map.get(k)`).
 * Modernize doc-comment code examples: convert module-function calls to dot notation, strip redundant implicit `compare`/`equal` arguments, and remove unnecessary inline lambda type annotations (#534).
 * Replace all uses of the deprecated `.vals()` array/blob iterator method with `.values()` across `src`, `test`, and `bench` (#530).
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 ## Next
+* Enforce `M0236` (suggest contextual dot notation) in `validate:docs` doc snippets and bump the pinned `moc` toolchain to 1.9.0, which ships the check — doc examples now fail validation if a module-function call could be written with dot notation (e.g. `Map.get(map, k, Nat.compare)` → `map.get(k)`).
 * Modernize doc-comment code examples: convert module-function calls to dot notation, strip redundant implicit `compare`/`equal` arguments, and remove unnecessary inline lambda type annotations (#534).
 * Replace all uses of the deprecated `.vals()` array/blob iterator method with `.values()` across `src`, `test`, and `bench` (#530).
 

--- a/mops.toml
+++ b/mops.toml
@@ -24,7 +24,7 @@ bench-helper = "0.0.3"
 moc = "1.6.0"
 
 [toolchain]
-moc = "1.9.0"
+moc = "1.16.0"
 wasmtime = "44.0.0"
 pocket-ic = "12.0.0"
 

--- a/mops.toml
+++ b/mops.toml
@@ -24,7 +24,7 @@ bench-helper = "0.0.3"
 moc = "1.6.0"
 
 [toolchain]
-moc = "1.8.0"
+moc = "1.9.0"
 wasmtime = "44.0.0"
 pocket-ic = "12.0.0"
 

--- a/test/ts/validate/docs.ts
+++ b/test/ts/validate/docs.ts
@@ -36,9 +36,9 @@ const testStatusEmojis: Record<TestResult["status"], string> = {
 
 const rootDirectory = join(__dirname, "../../..");
 
-// Treat redundant type instantiations (M0223) and `@deprecated` usages (M0154)
-// as errors in doc snippets — examples must never use deprecated APIs.
-const mocExtraFlags = ["-E=M0223,M0154"];
+// Treat redundant type instantiations (M0223), `@deprecated` usages (M0154),
+// and module-function calls (M0236) as errors in doc snippets.
+const mocExtraFlags = ["-E=M0223,M0154,M0236"];
 
 // Always use the mops-pinned `moc` so snippets compile against the exact
 // toolchain version the project targets. Never fall back to a dfx-provided moc.


### PR DESCRIPTION
Doc snippets must never use module-function calls when dot notation is available — but nothing currently enforces it. `M0236` (suggest contextual dot notation) only ships in newer moc, and this repo pins the toolchain at 1.8.0, so the pin is bumped alongside promoting the warning to an error in `validate:docs`:

- `test/ts/validate/docs.ts`: `-E=M0223,M0154` → `-E=M0223,M0154,M0236`
- `mops.toml`: `[toolchain] moc` 1.8.0 → **1.16.0** (newest available; ships M0236)

Because `docs.ts` changed, the `validate-docs` job runs **all** snippets. This PR intentionally ships only the enforcement: the failing snippets it surfaces are fixed in follow-ups, so the failure list here is the worklist. CI on this PR is the enumeration step (403 M0236 failures across src/ and src/pure/).

Co-Authored-By: Claude Code <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)